### PR TITLE
feat: allow connection redis options to be passed directly to constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "upstash-redis-level",
   "description": "@upstash/redis backed abstract-level database for Node.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,7 +14,6 @@
 
 import {RedisLevel} from './index'
 import 'isomorphic-fetch'
-import {Redis} from '@upstash/redis'
 
 const ModuleError = require('module-error')
 
@@ -23,21 +22,17 @@ const keyNotFoundError = (key: string) => new ModuleError(`Key ${key} was not fo
 })
 
 describe('redis-level', () => {
-  let redis: Redis
   let level: RedisLevel
-  beforeEach(() => {
-    redis = new Redis({
-      url: process.env.UPSTASH_REDIS_REST_URL || 'http://localhost:8079',
-      token: process.env.UPSTASH_REDIS_REST_TOKEN || 'mytoken',
-      automaticDeserialization: true,
-    })
-  })
 
   describe('json encoding', () => {
     let namespace = `test-${Math.random()}`
     beforeEach(async () => {
       level = new RedisLevel<string, string>({
-        redis,
+        redis: {
+          url: process.env.UPSTASH_REDIS_REST_URL || 'http://localhost:8079',
+          token: process.env.UPSTASH_REDIS_REST_TOKEN || 'mytoken',
+          automaticDeserialization: true,
+        },
         namespace,
         keyEncoding: 'json',
         valueEncoding: 'json',
@@ -62,7 +57,11 @@ describe('redis-level', () => {
   describe('default encoding', () => {
     beforeEach(async () => {
       level = new RedisLevel<string, string>({
-        redis,
+        redis: {
+          url: process.env.UPSTASH_REDIS_REST_URL || 'http://localhost:8079',
+          token: process.env.UPSTASH_REDIS_REST_TOKEN || 'mytoken',
+          automaticDeserialization: true,
+        },
         namespace: `test-${Math.random()}`
       })
     })


### PR DESCRIPTION
Optionally allow connection options instead of redis instance to be passed to constructor